### PR TITLE
feat(citizen-devtools): add GET_RESOURCE_MONITOR_DATA

### DIFF
--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -10,6 +10,8 @@
 #ifndef IS_FXSERVER
 #include <Pool.h>
 #include <Streaming.h>
+#else
+#include <ScriptEngine.h>
 #endif
 
 #include <iomanip>
@@ -787,6 +789,15 @@ static InitFunction initFunction([]()
 			ImGui::End();
 		}
 	});
+
+#ifdef IS_FXSERVER
+	fx::ScriptEngine::RegisterNativeHandler("GET_RESOURCE_MONITOR_DATA", [](fx::ScriptContext& context) {
+		std::shared_lock _(gResourceMonitorMutex);
+		auto& data = gResourceMonitor->GetResourceDatas();
+	
+		context.SetResult(data);
+	});
+#endif
 
 #ifndef IS_FXSERVER
 	static ConVar<bool> poolVar("net_showPools", ConVar_Archive | ConVar_UserPref, false, &m_enabledPools);


### PR DESCRIPTION
### Goal of this PR
The ability to track the performance of resources via scripts. Under Linux, this is the only way to determine the performance of resources.


### How is this PR achieving the goal

Return data from the resource monitor


### This PR applies to the following area(s)
Server, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


